### PR TITLE
documentation for 'ApplicationName' property restored

### DIFF
--- a/documentation/92/connect.md
+++ b/documentation/92/connect.md
@@ -221,3 +221,8 @@ connection.
 * `jaasApplicationName = String`
 
 	Specifies the name of the JAAS system or application login configuration. 
+	
+* `ApplicationName = String`
+      	Specifies the name of the application that is using the connection. This allows a database administrator 
+	to see what applications are connected to the server and what resources they are using through views like 
+	pg_stat_activity.

--- a/documentation/head/connect.md
+++ b/documentation/head/connect.md
@@ -221,3 +221,8 @@ connection.
 * `jaasApplicationName = String`
 
 	Specifies the name of the JAAS system or application login configuration. 
+	
+* `ApplicationName = String`
+      	Specifies the name of the application that is using the connection. This allows a database administrator 
+	to see what applications are connected to the server and what resources they are using through views like 
+	pg_stat_activity.


### PR DESCRIPTION
It looks like the documentation for the 'ApplicationName' property disappeared: between 9.1 and 9.2:
* Before: http://jdbc.postgresql.org/documentation/91/connect.html#connection-parameters, 
* After: http://jdbc.postgresql.org/documentation/92/connect.html#connection-parameters

From the docs, it looks like the property was absorbed into the 'jaasApplicationName'.

It looks like the code still uses both 'jaasApplicationName' and  'ApplicationName', though:

```
pgjdbc> grep -r ApplicationName .
./doc/pgjdbc.xml:       <term><varname>jaasApplicationName</varname> = <type>String</type></term>
./doc/pgjdbc.xml:       <term><varname>ApplicationName</varname> = <type>String</type></term>
./org/postgresql/core/v2/ConnectionFactoryImpl.java:        String appName = info.getProperty("ApplicationName");
./org/postgresql/core/v3/ConnectionFactoryImpl.java:                String appName = info.getProperty("ApplicationName");
./org/postgresql/core/v3/ConnectionFactoryImpl.java:                                    info.getProperty("jaasApplicationName"),
./org/postgresql/core/v3/ConnectionFactoryImpl.java:        String appName = info.getProperty("ApplicationName");
./org/postgresql/Driver.java.in:                { "jaasApplicationName", Boolean.FALSE,
./org/postgresql/ds/common/BaseDataSource.java:    public void setApplicationName(String applicationName)
./org/postgresql/ds/common/BaseDataSource.java:    public String getApplicationName()
./org/postgresql/ds/common/BaseDataSource.java:            sb.append("&ApplicationName=");
./org/postgresql/ds/common/BaseDataSource.java:     	applicationName = p.getProperty("ApplicationName");
./org/postgresql/ds/common/BaseDataSource.java:            ref.add(new StringRefAddr("ApplicationName", applicationName));
./org/postgresql/gss/MakeGSS.java:    public static void authenticate(PGStream pgStream, String host, String user, String password, String jaasApplicationName, String kerberosServerName, Logger logger, boolean useSpnego) throws IOException, SQLException
./org/postgresql/gss/MakeGSS.java:        if (jaasApplicationName == null)
./org/postgresql/gss/MakeGSS.java:            jaasApplicationName = "pgjdbc";
./org/postgresql/gss/MakeGSS.java:                LoginContext lc = new LoginContext(jaasApplicationName, new GSSCallbackHandler(user, password));
./org/postgresql/jdbc4/AbstractJdbc4Connection.java:            String appName = info.getProperty("ApplicationName");
./org/postgresql/jdbc4/AbstractJdbc4Connection.java:            _clientInfo.put("ApplicationName", appName);
./org/postgresql/jdbc4/AbstractJdbc4Connection.java:        if (haveMinimumServerVersion("9.0") && "ApplicationName".equals(name)) {
./org/postgresql/jdbc4/AbstractJdbc4Connection.java:                throw new SQLClientInfoException(GT.tr("Failed to set ClientInfo property: {0}", "ApplicationName"), sqle.getSQLState(), failures, sqle);
./org/postgresql/jdbc4/AbstractJdbc4Connection.java:        for (String name : new String[] { "ApplicationName" })
./org/postgresql/jdbc4/AbstractJdbc4DatabaseMetaData.java:            tuple[0] = connection.encodeString("ApplicationName");
./org/postgresql/test/jdbc4/ClientInfoTest.java:        _conn.setClientInfo("ApplicationName", "my app");
./org/postgresql/test/jdbc4/ClientInfoTest.java:        assertEquals("my app", _conn.getClientInfo("ApplicationName"));
./org/postgresql/test/jdbc4/ClientInfoTest.java:        assertEquals("my app", _conn.getClientInfo().getProperty("ApplicationName"));
./org/postgresql/test/jdbc4/ClientInfoTest.java:        props.put("ApplicationName", "my app");
./org/postgresql/test/jdbc4/ClientInfoTest.java:        assertEquals("my app", _conn.getClientInfo("ApplicationName"));
./org/postgresql/test/jdbc4/ClientInfoTest.java:        assertEquals("my app", _conn.getClientInfo().getProperty("ApplicationName"));
./org/postgresql/test/jdbc4/ClientInfoTest.java:        _conn.setClientInfo("ApplicationName", "my app");
./org/postgresql/test/jdbc4/ClientInfoTest.java:        String applicationName = _conn.getClientInfo("ApplicationName");
./org/postgresql/test/jdbc4/DatabaseMetaDataTest.java:        assertEquals("ApplicationName", rs.getString("NAME"));
>
```