### PR TITLE
fix: replace xml escapes in code samples with < and >

### DIFF
--- a/documentation/92/binary-data.md
+++ b/documentation/92/binary-data.md
@@ -127,7 +127,7 @@ To insert an image, you would use:
 `// Copy the data from the file to the large object`  
 `byte buf[] = new byte[2048];`  
 `int s, tl = 0;`  
-`while ((s = fis.read(buf, 0, 2048)) &gt; 0)`  
+`while ((s = fis.read(buf, 0, 2048)) > 0)`
 `{`  
 &nbsp;&nbsp;&nbsp;`obj.write(buf, 0, s);`  
 &nbsp;&nbsp;&nbsp;`tl += s;`  

--- a/documentation/92/server-prepare.md
+++ b/documentation/92/server-prepare.md
@@ -63,7 +63,7 @@ public class ServerSidePreparedStatement
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
 
-		for (int i=1; i&lt;=5; i++)
+		for (int i=1; i<=5; i++)
 		{
 			pstmt.setInt(1,i);
 			boolean usingServerPrepare = pgstmt.isUseServerPrepare();

--- a/documentation/93/binary-data.md
+++ b/documentation/93/binary-data.md
@@ -127,7 +127,7 @@ To insert an image, you would use:
 `// Copy the data from the file to the large object`  
 `byte buf[] = new byte[2048];`  
 `int s, tl = 0;`  
-`while ((s = fis.read(buf, 0, 2048)) &gt; 0)`  
+`while ((s = fis.read(buf, 0, 2048)) > 0)`
 `{`  
 &nbsp;&nbsp;&nbsp;`obj.write(buf, 0, s);`  
 &nbsp;&nbsp;&nbsp;`tl += s;`  

--- a/documentation/93/server-prepare.md
+++ b/documentation/93/server-prepare.md
@@ -63,7 +63,7 @@ public class ServerSidePreparedStatement
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
 
-		for (int i=1; i&lt;=5; i++)
+		for (int i=1; i<=5; i++)
 		{
 			pstmt.setInt(1,i);
 			boolean usingServerPrepare = pgstmt.isUseServerPrepare();

--- a/documentation/94/binary-data.md
+++ b/documentation/94/binary-data.md
@@ -127,7 +127,7 @@ To insert an image, you would use:
 `// Copy the data from the file to the large object`  
 `byte buf[] = new byte[2048];`  
 `int s, tl = 0;`  
-`while ((s = fis.read(buf, 0, 2048)) &gt; 0)`  
+`while ((s = fis.read(buf, 0, 2048)) > 0)`
 `{`  
 &nbsp;&nbsp;&nbsp;`obj.write(buf, 0, s);`  
 &nbsp;&nbsp;&nbsp;`tl += s;`  

--- a/documentation/94/server-prepare.md
+++ b/documentation/94/server-prepare.md
@@ -63,7 +63,7 @@ public class ServerSidePreparedStatement
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
 
-		for (int i=1; i&lt;=5; i++)
+		for (int i=1; i<=5; i++)
 		{
 			pstmt.setInt(1,i);
 			boolean usingServerPrepare = pgstmt.isUseServerPrepare();

--- a/documentation/head/binary-data.md
+++ b/documentation/head/binary-data.md
@@ -127,7 +127,7 @@ To insert an image, you would use:
 `// Copy the data from the file to the large object`  
 `byte buf[] = new byte[2048];`  
 `int s, tl = 0;`  
-`while ((s = fis.read(buf, 0, 2048)) &gt; 0)`  
+`while ((s = fis.read(buf, 0, 2048)) > 0)`
 `{`  
 &nbsp;&nbsp;&nbsp;`obj.write(buf, 0, s);`  
 &nbsp;&nbsp;&nbsp;`tl += s;`  

--- a/documentation/head/server-prepare.md
+++ b/documentation/head/server-prepare.md
@@ -63,7 +63,7 @@ public class ServerSidePreparedStatement
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
 
-		for (int i=1; i&lt;=5; i++)
+		for (int i=1; i<=5; i++)
 		{
 			pstmt.setInt(1,i);
 			boolean usingServerPrepare = pgstmt.isUseServerPrepare();


### PR DESCRIPTION
Fix a couple places where code examples had xml escapes rather than < or >.

I'm guessing this happened from the automated conversion from the old site to the new jekyll based one.