### PR TITLE
docs: defaultRowFetchSize connection property

### DIFF
--- a/documentation/head/connect.md
+++ b/documentation/head/connect.md
@@ -184,6 +184,17 @@ connection.
 	execution of the same `PreparedStatement` object. More information on
 	server side prepared statements is available in the section called
 	[“Server Prepared Statements”](server-prepare.html).
+	
+* `defaultRowFetchSize = int`
+	
+	Determine the number of rows fetched in `ResultSet`
+	by one fetch with trip to the database. Limiting the number of rows are fetch with 
+	each trip to the database allow avoids unnecessary memory consumption 
+	and as a consequence `OutOfMemoryException`.
+	
+	The default is zero, meaning that in `ResultSet` will be fetch all rows at once. 
+	Negative number is not available.
+	
  
 * `loginTimeout = int`
 


### PR DESCRIPTION
Add docs for property defaultRowFetchSize that use for define count rows that should be fetched by one round trip to database. It feature add in https://github.com/pgjdbc/pgjdbc/pull/287