### PR TITLE
Maintenance Update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 name: PostgreSQL JDBC driver website
 markdown: redcarpet
-pygments: true
+highlighter: true

--- a/_includes/submenu_community.html
+++ b/_includes/submenu_community.html
@@ -3,6 +3,7 @@
 						<ul>
 							<li><a href="community.html">Community</a></li>
 							<li><a href="mailinglist.html">Mailing List</a></li>
+							<li><a href="../development/development.html">Development</a><li>
 							<li><a href="contributors.html">Contributors</a></li>
 						</ul>
 					</div> <!-- pgSideNam -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -100,7 +100,7 @@
 			<div id="pgFooter">
 				<a class="navFooter" href="http://www.postgresql.org/about/privacypolicy">Privacy Policy</a> |
 				<a class="navFooter" href="http://www.postgresql.org/about/">About PostgreSQL</a><br/>
-				Copyright &copy; 1996-2013 The PostgreSQL Global Development Group
+				Copyright &copy; 1996-2015 The PostgreSQL Global Development Group
 			</div> <!-- pgFooter -->
 		</div> <!-- pgContainer -->
 	</div> <!-- pgContainerWrap -->

--- a/about/license.html
+++ b/about/license.html
@@ -19,7 +19,7 @@ nav: ../
 					<hr />
 
 					<pre  style="font-family: serif;">
-Copyright (c) 1997-2011, PostgreSQL Global Development Group
+Copyright (c) 1997-2015, PostgreSQL Global Development Group
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/community/contributors.html
+++ b/community/contributors.html
@@ -58,69 +58,31 @@ nav: ../
 							be happy to recognize you for it.  Just let us know.
 						</p>
 						<ul>
-							<li>Jan Andre le Roux
-								<ul>
-									<li>ResultSetMetaData information based on the V3 protocol</li>
-								</ul>
-							</li>
-							<li>Jaroslaw J. Pyszny
-								<ul>
-									<li>Improve MetaData regarding the serial datatype</li>
-								</ul>
-							</li>
-							<li>Ulrich Meis
-								<ul>
-									<li>Allow users to customize the SSL connection</li>
-								</ul>
-							</li>
-							<li>Xavier Poinsard
-								<ul>
-									<li>Standard escaped functions {fn ...() }</li>
-								</ul>
-							</li>
-							<li>Oliver Siegmar
-								<ul>
-									<li>Support for infinity in the timestamp datatype</li>
-									<li>Make PGInterval able to decode and manipulate interval data</li>
-								</ul>
-							</li>
-							<li>Michael Barker
-								<ul>
-									<li>Blob write and position methods.</li>
-								</ul>
-							</li>
-							<li>Andras Kadinger
-								<ul>
-									<li>Support asynchronous notification retrieval.</li>
-								</ul>
-							</li>
-							<li>Heikki Linnakangas
-								<ul>
-									<li>XADataSource implementation.</li>
-								</ul>
-							</li>
-							<li>Luis Vilar Flores
-								<ul>
-									<li>Reduce memory usage retrieving bytea data.</li>
-								</ul>
-							</li>
-							<li>Michael Paesold
-								<ul>
-									<li>Correctly parse dollar quotes and comments.</li>
-									<li>Work with standard_conforming_strings = on.</li>
-								</ul>
-							</li>
-							<li>Mikko Tiihonen
-								<ul>
-									<li>Improve speed of parsing ResultSet data.</li>
-								</ul>
-							</li>
-							<li>Marek Lewczuk
-								<ul>
-									<li>Support multi-dimensional arrays and NULL array elements.</li>
-								</ul>
-							</li>
-						</ul>
+							<li>Alexis Meneses</li>
+							<li>Andras Kadinger</li>
+							<li>Barry Lind</li>
+							<li>Bruce Momjian</li>
+							<li>Craig Ringer
+							<li>Heikki Linnakangas</li>
+							<li>Jan Andre le Roux</li>
+							<li>Jaroslaw J. Pyszny</li>
+							<li>Jeremy Whiting</li>
+							<li>Luis Vilar Flores</li>
+							<li>Marc G. Fournier</li>
+							<li>Marek Lewczuk</li>
+							<li>Michael Barker</li>
+							<li>Michael Paesold</li>
+							<li>Mikko Tiihonen</li>
+							<li>Oliver Jowett</li>
+							<li>Oliver Siegmar</li>
+							<li>Peter Eisentraut</li>
+							<li>Peter Mount</li>
+							<li>Sehrope Sarkuni</li>
+							<li>Stephen Nelson</li>
+							<li>Ulrich Meis</li>
+							<li>Vladimir Sitnikov</li>
+							<li>Xavier Poinsard</li>
+						</ul><br>
 					</div>
 					<hr />
 

--- a/community/mailinglist.html
+++ b/community/mailinglist.html
@@ -15,7 +15,7 @@ nav: ../
 							<ul>
 								<li><a href="#before">Before Mailing Anyone</a></li>
 								<li><a href="#general">General List - pgsql-jdbc@postgresql.org</a></li>
-								<li><a href="#commits">Commit Messages - jdbc-commits@pgfoundry.org</a></li>
+								<li><a href="#commits">Commit Messages - jdbc-commits@pgfoundry.org, GitHub</a></li>
 							</ul>
 						</div>
 					</div>
@@ -69,7 +69,7 @@ nav: ../
 					<hr />
 	
 					<a name="commits"></a>
-					<h2 class="underlined_10">Commit Messages - jdbc-commits@pgfoundry.org</h2>
+					<h2 class="underlined_10">Commit Messages - jdbc-commits@pgfoundry.org, GitHub</h2>
 					<div>
 						<p>
 							This mailing list is for people interested in carefully monitoring

--- a/community/mailinglist.html
+++ b/community/mailinglist.html
@@ -15,7 +15,7 @@ nav: ../
 							<ul>
 								<li><a href="#before">Before Mailing Anyone</a></li>
 								<li><a href="#general">General List - pgsql-jdbc@postgresql.org</a></li>
-								<li><a href="#commits">Commit Messages - jdbc-commits@pgfoundry.org, GitHub</a></li>
+								<li><a href="#commits">Commit Messages - GitHub</a></li>
 							</ul>
 						</div>
 					</div>
@@ -69,21 +69,21 @@ nav: ../
 					<hr />
 	
 					<a name="commits"></a>
-					<h2 class="underlined_10">Commit Messages - jdbc-commits@pgfoundry.org, GitHub</h2>
+					<h2 class="underlined_10">Commit Messages - GitHub</h2>
 					<div>
-						<p>
-							This mailing list is for people interested in carefully monitoring
-							the development process.  The mailing list was active until the code
-							base was transfered to GitHub in late 2012. Every commit to this earlier
-							CVS repository sent out an email with the log message and links to diffs.
-							So the archive of this list, <a href="http://lists.pgfoundry.org/mailman/listinfo/jdbc-commits" target="_blank">pgfoundry site</a>,
-							holds the history of activity with the driver prior to 2013.
-						</p>
+		
 						<p>
 							Currently activity on commits is best observed directly from the git
 							repository hosted with <a href="https://github.com/pgjdbc/pgjdbc" target="_blank">GitHub</a>.
 							The console tool, gitk, available with a git installation is an excellent
 							GUI tool to observe commits.
+						</p>
+						<p>
+							A mailing list was active until the code base was transfered to GitHub in
+							late 2012. Every commit to this earlier CVS repository sent out an email
+							with the log message and links to diffs. So the archive of this list,
+							<a href="http://lists.pgfoundry.org/mailman/listinfo/jdbc-commits" target="_blank">pgfoundry site</a>,
+							holds the history of activity with the driver prior to 2013.
 						</p>
 					</div>
 				</div> <!-- pgContentWrap -->

--- a/development/website.html
+++ b/development/website.html
@@ -37,7 +37,7 @@ nav: ../
 						<p>
 							To get started please read the <a href="http://jekyllrb.com" target="_blank">Jekyll website</a>
 							for installation instructions for that tool. After installing Jekyll you need to get
-							the website project.  This is available from the same <a href="../development/git.html">git repository</a>
+							the website project.  This is available from the same <a href="https://github.com/pgjdbc/www" target="_blank">git repository</a>
 							that the main source code is, it's just a different module, <span style="font-family: Courier New,Courier,monospace;">www</span>.
 							Checkout this module and then within the top level directory of the module simply
 							run <span style="font-family: Courier New,Courier,monospace;">jekyll build</span>.

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -35,8 +35,6 @@ nav: ../
 * [Archived Versions 8.0-8.4](pgjdbc_changelog-8.0-8.4.tar.gz)
 * [All Committers](#all-committers)
 
-[![](../media/img/rss.png)](../changes.rss)
-
 <a name="introduction"></a>
 ## Introduction and explanation of symbols
 

--- a/documentation/documentation.md
+++ b/documentation/documentation.md
@@ -10,7 +10,7 @@ nav: ../
 * [9.3](93/index.html) Download - [postgresql-jdbc-93-doc.tar.gz](postgresql-jdbc-93-doc.tar.gz)
 * [9.2](92/index.html) Download - [postgresql-jdbc-92-doc.tar.gz](postgresql-jdbc-92-doc.tar.gz)
 * [9.1](91/index.html) Download - [postgresql-jdbc-91-doc.tar.gz](postgresql-jdbc-91-doc.tar.gz)
-* [9.0](90/index.html) Download - [postgresql-jdbc-84-doc.tar.gz](postgresql-jdbc-84-doc.tar.gz)
+* [9.0](84/index.html) Download - [postgresql-jdbc-84-doc.tar.gz](postgresql-jdbc-84-doc.tar.gz)
 * [8.4](84/index.html) Download - [postgresql-jdbc-84-doc.tar.gz](postgresql-jdbc-84-doc.tar.gz)
 * [8.3](83/index.html) Download - [postgresql-jdbc-83-doc.tar.gz](postgresql-jdbc-83-doc.tar.gz)
 * [8.2](82/index.html) Download - [postgresql-jdbc-82-doc.tar.gz](postgresql-jdbc-82-doc.tar.gz)

--- a/download.md
+++ b/download.md
@@ -18,7 +18,7 @@ nav:
 ## About
 				
 Binary JAR file downloads of the JDBC driver are available here
-and the current version with [Maven Repository](http://mvnrepository.com/artifact/org.postgresql).
+and the current version with [Maven Central Repository](https://search.maven.org/#search|gav|1|g%3A%22org.postgresql%22%20AND%20a%3A%22postgresql%22).
 Because Java is platform neutral, it is a simple process of just
 downloading the appropriate JAR file and dropping it into your
 classpath.  Source versions are also available here for recent


### PR DESCRIPTION
Updated copyright date in default.html and license.html. Deprecated configuration option update
in _config.yml. Mailing list header to include GitHub. Updated contributors per release_notes.sh
and abbreviated. Git repository for WWW module link. Removed reference to changes.rss in
documentation changelog. Changed link in documentation for 9.0 index files to 8.4 directory. 
