### PR TITLE
docs: Update docs to use Wrapper API

### DIFF
--- a/documentation/92/binary-data.md
+++ b/documentation/92/binary-data.md
@@ -112,7 +112,7 @@ To insert an image, you would use:
 `conn.setAutoCommit(false);``<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `// Create a new large object`  
 `long oid = lobj.createLO(LargeObjectManager.READ | LargeObjectManager.WRITE);`<br />
@@ -153,7 +153,7 @@ Retrieving the image from the Large Object:
 `conn.setAutoCommit(false);`<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `PreparedStatement ps = conn.prepareStatement("SELECT imgoid FROM imageslo WHERE imgname = ?");`  
 `ps.setString(1, "myimage.gif");`  

--- a/documentation/92/ext.md
+++ b/documentation/92/ext.md
@@ -33,4 +33,4 @@ return value of `Driver.getConnection()`. For example:
 `Connection db = Driver.getConnection(url, username, password);`  
 `// ...`  
 `// later on`  
-`Fastpath fp = ((org.postgresql.PGConnection)db).getFastpathAPI();`
+`Fastpath fp = db.unwrap(org.postgresql.PGConnection.class).getFastpathAPI();`

--- a/documentation/92/listennotify.md
+++ b/documentation/92/listennotify.md
@@ -66,7 +66,7 @@ class Listener extends Thread
 	Listener(Connection conn) throws SQLException
 	{
 		this.conn = conn;
-		this.pgconn = (org.postgresql.PGConnection)conn;
+		this.pgconn = conn.unwrap(org.postgresql.PGConnection.class);
 		Statement stmt = conn.createStatement();
 		stmt.execute("LISTEN mymessage");
 		stmt.close();

--- a/documentation/92/server-prepare.md
+++ b/documentation/92/server-prepare.md
@@ -58,7 +58,7 @@ public class ServerSidePreparedStatement
 		PreparedStatement pstmt = conn.prepareStatement("SELECT ?");
 
 		// cast to the pg extension interface
-		org.postgresql.PGStatement pgstmt = (org.postgresql.PGStatement)pstmt;
+		org.postgresql.PGStatement pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);
 
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
@@ -106,16 +106,16 @@ the value will be the default for all of it's children.
 
 `// see that the connection has picked up the correct threshold from the url`  
 `Connection conn = DriverManager.getConnection(url,"test","");`  
-`pgconn = (org.postgresql.PGConnection)conn;`  
+`pgconn = conn.unwrap(org.postgresql.PGConnection.class);`  
 `System.out.println(pgconn.getPrepareThreshold()); // Should be 3`
 
 `// see that the statement has picked up the correct threshold from the connection`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 3`
 
 `// change the connection's threshold and ensure that new statements pick it up`  
 `pgconn.setPrepareThreshold(5);`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 5`

--- a/documentation/93/binary-data.md
+++ b/documentation/93/binary-data.md
@@ -112,7 +112,7 @@ To insert an image, you would use:
 `conn.setAutoCommit(false);``<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `// Create a new large object`  
 `long oid = lobj.createLO(LargeObjectManager.READ | LargeObjectManager.WRITE);`<br />
@@ -153,7 +153,7 @@ Retrieving the image from the Large Object:
 `conn.setAutoCommit(false);`<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `PreparedStatement ps = conn.prepareStatement("SELECT imgoid FROM imageslo WHERE imgname = ?");`  
 `ps.setString(1, "myimage.gif");`  

--- a/documentation/93/ext.md
+++ b/documentation/93/ext.md
@@ -33,4 +33,4 @@ return value of `Driver.getConnection()`. For example:
 `Connection db = Driver.getConnection(url, username, password);`  
 `// ...`  
 `// later on`  
-`Fastpath fp = ((org.postgresql.PGConnection)db).getFastpathAPI();`
+`Fastpath fp = db.unwrap(org.postgresql.PGConnection.class).getFastpathAPI();`

--- a/documentation/93/listennotify.md
+++ b/documentation/93/listennotify.md
@@ -66,7 +66,7 @@ class Listener extends Thread
 	Listener(Connection conn) throws SQLException
 	{
 		this.conn = conn;
-		this.pgconn = (org.postgresql.PGConnection)conn;
+		this.pgconn = conn.unwrap(org.postgresql.PGConnection.class);
 		Statement stmt = conn.createStatement();
 		stmt.execute("LISTEN mymessage");
 		stmt.close();

--- a/documentation/93/server-prepare.md
+++ b/documentation/93/server-prepare.md
@@ -58,7 +58,7 @@ public class ServerSidePreparedStatement
 		PreparedStatement pstmt = conn.prepareStatement("SELECT ?");
 
 		// cast to the pg extension interface
-		org.postgresql.PGStatement pgstmt = (org.postgresql.PGStatement)pstmt;
+		org.postgresql.PGStatement pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);
 
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
@@ -106,16 +106,16 @@ the value will be the default for all of it's children.
 
 `// see that the connection has picked up the correct threshold from the url`  
 `Connection conn = DriverManager.getConnection(url,"test","");`  
-`pgconn = (org.postgresql.PGConnection)conn;`  
+`pgconn = conn.unwrap(org.postgresql.PGConnection.class);`  
 `System.out.println(pgconn.getPrepareThreshold()); // Should be 3`
 
 `// see that the statement has picked up the correct threshold from the connection`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 3`
 
 `// change the connection's threshold and ensure that new statements pick it up`  
 `pgconn.setPrepareThreshold(5);`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 5`

--- a/documentation/94/binary-data.md
+++ b/documentation/94/binary-data.md
@@ -112,7 +112,7 @@ To insert an image, you would use:
 `conn.setAutoCommit(false);``<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `// Create a new large object`  
 `long oid = lobj.createLO(LargeObjectManager.READ | LargeObjectManager.WRITE);`<br />
@@ -153,7 +153,7 @@ Retrieving the image from the Large Object:
 `conn.setAutoCommit(false);`<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `PreparedStatement ps = conn.prepareStatement("SELECT imgoid FROM imageslo WHERE imgname = ?");`  
 `ps.setString(1, "myimage.gif");`  

--- a/documentation/94/ext.md
+++ b/documentation/94/ext.md
@@ -33,4 +33,4 @@ return value of `Driver.getConnection()`. For example:
 `Connection db = Driver.getConnection(url, username, password);`  
 `// ...`  
 `// later on`  
-`Fastpath fp = ((org.postgresql.PGConnection)db).getFastpathAPI();`
+`Fastpath fp = db.unwrap(org.postgresql.PGConnection.class).getFastpathAPI();`

--- a/documentation/94/listennotify.md
+++ b/documentation/94/listennotify.md
@@ -66,7 +66,7 @@ class Listener extends Thread
 	Listener(Connection conn) throws SQLException
 	{
 		this.conn = conn;
-		this.pgconn = (org.postgresql.PGConnection)conn;
+		this.pgconn = conn.unwrap(org.postgresql.PGConnection.class);
 		Statement stmt = conn.createStatement();
 		stmt.execute("LISTEN mymessage");
 		stmt.close();

--- a/documentation/94/server-prepare.md
+++ b/documentation/94/server-prepare.md
@@ -58,7 +58,7 @@ public class ServerSidePreparedStatement
 		PreparedStatement pstmt = conn.prepareStatement("SELECT ?");
 
 		// cast to the pg extension interface
-		org.postgresql.PGStatement pgstmt = (org.postgresql.PGStatement)pstmt;
+		org.postgresql.PGStatement pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);
 
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
@@ -106,16 +106,16 @@ the value will be the default for all of it's children.
 
 `// see that the connection has picked up the correct threshold from the url`  
 `Connection conn = DriverManager.getConnection(url,"test","");`  
-`pgconn = (org.postgresql.PGConnection)conn;`  
+`pgconn = conn.unwrap(org.postgresql.PGConnection.class);`  
 `System.out.println(pgconn.getPrepareThreshold()); // Should be 3`
 
 `// see that the statement has picked up the correct threshold from the connection`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 3`
 
 `// change the connection's threshold and ensure that new statements pick it up`  
 `pgconn.setPrepareThreshold(5);`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 5`

--- a/documentation/head/binary-data.md
+++ b/documentation/head/binary-data.md
@@ -112,7 +112,7 @@ To insert an image, you would use:
 `conn.setAutoCommit(false);``<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `// Create a new large object`  
 `long oid = lobj.createLO(LargeObjectManager.READ | LargeObjectManager.WRITE);`<br />
@@ -153,7 +153,7 @@ Retrieving the image from the Large Object:
 `conn.setAutoCommit(false);`<br />
 
 `// Get the Large Object Manager to perform operations with`  
-`LargeObjectManager lobj = ((org.postgresql.PGConnection)conn).getLargeObjectAPI();`<br />
+`LargeObjectManager lobj = conn.unwrap(org.postgresql.PGConnection.class).getLargeObjectAPI();`<br />
 
 `PreparedStatement ps = conn.prepareStatement("SELECT imgoid FROM imageslo WHERE imgname = ?");`  
 `ps.setString(1, "myimage.gif");`  

--- a/documentation/head/ext.md
+++ b/documentation/head/ext.md
@@ -33,4 +33,4 @@ return value of `Driver.getConnection()`. For example:
 `Connection db = Driver.getConnection(url, username, password);`  
 `// ...`  
 `// later on`  
-`Fastpath fp = ((org.postgresql.PGConnection)db).getFastpathAPI();`
+`Fastpath fp = db.unwrap(org.postgresql.PGConnection.class).getFastpathAPI();`

--- a/documentation/head/listennotify.md
+++ b/documentation/head/listennotify.md
@@ -66,7 +66,7 @@ class Listener extends Thread
 	Listener(Connection conn) throws SQLException
 	{
 		this.conn = conn;
-		this.pgconn = (org.postgresql.PGConnection)conn;
+		this.pgconn = conn.unwrap(org.postgresql.PGConnection.class);
 		Statement stmt = conn.createStatement();
 		stmt.execute("LISTEN mymessage");
 		stmt.close();

--- a/documentation/head/server-prepare.md
+++ b/documentation/head/server-prepare.md
@@ -58,7 +58,7 @@ public class ServerSidePreparedStatement
 		PreparedStatement pstmt = conn.prepareStatement("SELECT ?");
 
 		// cast to the pg extension interface
-		org.postgresql.PGStatement pgstmt = (org.postgresql.PGStatement)pstmt;
+		org.postgresql.PGStatement pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);
 
 		// on the third execution start using server side statements
 		pgstmt.setPrepareThreshold(3);
@@ -106,16 +106,16 @@ the value will be the default for all of it's children.
 
 `// see that the connection has picked up the correct threshold from the url`  
 `Connection conn = DriverManager.getConnection(url,"test","");`  
-`pgconn = (org.postgresql.PGConnection)conn;`  
+`pgconn = conn.unwrap(org.postgresql.PGConnection.class);`  
 `System.out.println(pgconn.getPrepareThreshold()); // Should be 3`
 
 `// see that the statement has picked up the correct threshold from the connection`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 3`
 
 `// change the connection's threshold and ensure that new statements pick it up`  
 `pgconn.setPrepareThreshold(5);`  
 `PreparedStatement pstmt = conn.prepareStatement("SELECT ?");`  
-`pgstmt = (org.postgresql.PGStatement)pstmt;`  
+`pgstmt = pstmt.unwrap(org.postgresql.PGStatement.class);`  
 `System.out.println(pgstmt.getPrepareThreshold()); // Should be 5`


### PR DESCRIPTION
Since the driver is Java 6/JDBC 4.0 and later only we can update the
documentation examples to use the `Wrapper` API. This has the advantage
that it also works with third party connection pools eg. in a Java EE
environment.