### PR TITLE
doc: Remove Sun references and URLs

### DIFF
--- a/documentation/92/escapes.md
+++ b/documentation/92/escapes.md
@@ -23,7 +23,7 @@ a special escape syntax is used to specify the generic commands the developer
 wants to be run. The JDBC driver translates these escape sequences into native
 syntax for its specific database. For more information consult the section 4.1.5
 from the [JDBC Technology Guide](http://java.sun.com/j2se/1.4.2/docs/guide/jdbc/getstart/statement.html#999472)
-(bundled with the Sun™ JRE documentation) and the section 13.4 from the
+(bundled with the Oracle™ JRE documentation) and the section 13.4 from the
 [JDBC 3.0 specification](http://java.sun.com/products/jdbc/download.html#corespec30).
 
 The parsing of the sql statements for these escapes can be disabled using

--- a/documentation/92/reading.md
+++ b/documentation/92/reading.md
@@ -10,8 +10,8 @@ next: index.html
 ---
 
 If you have not yet read it, you are advised you read the JDBC API Documentation
-(supplied with Sun's JDK) and the JDBC Specification.  Both are available from
-[http://java.sun.com/products/jdbc/index.jsp](http://java.sun.com/products/jdbc/index.jsp).
+(supplied with Oracle's JDK) and the JDBC Specification.  Both are available from
+[http://www.oracle.com/technetwork/java/javase/jdbc/index.html](http://www.oracle.com/technetwork/java/javase/jdbc/index.html).
 
 [http://jdbc.postgresql.org/index.html](http://jdbc.postgresql.org/index.html)
 contains updated information not included in this manual including Javadoc class

--- a/documentation/93/escapes.md
+++ b/documentation/93/escapes.md
@@ -23,7 +23,7 @@ a special escape syntax is used to specify the generic commands the developer
 wants to be run. The JDBC driver translates these escape sequences into native
 syntax for its specific database. For more information consult the section 4.1.5
 from the [JDBC Technology Guide](http://java.sun.com/j2se/1.4.2/docs/guide/jdbc/getstart/statement.html#999472)
-(bundled with the Sun™ JRE documentation) and the section 13.4 from the
+(bundled with the Oracle™ JRE documentation) and the section 13.4 from the
 [JDBC 3.0 specification](http://java.sun.com/products/jdbc/download.html#corespec30).
 
 The parsing of the sql statements for these escapes can be disabled using

--- a/documentation/93/reading.md
+++ b/documentation/93/reading.md
@@ -10,8 +10,8 @@ next: index.html
 ---
 
 If you have not yet read it, you are advised you read the JDBC API Documentation
-(supplied with Sun's JDK) and the JDBC Specification.  Both are available from
-[http://java.sun.com/products/jdbc/index.jsp](http://java.sun.com/products/jdbc/index.jsp).
+(supplied with Oracle's JDK) and the JDBC Specification.  Both are available from
+[http://www.oracle.com/technetwork/java/javase/jdbc/index.html](http://www.oracle.com/technetwork/java/javase/jdbc/index.html).
 
 [http://jdbc.postgresql.org/index.html](http://jdbc.postgresql.org/index.html)
 contains updated information not included in this manual including Javadoc class

--- a/documentation/94/escapes.md
+++ b/documentation/94/escapes.md
@@ -23,7 +23,7 @@ a special escape syntax is used to specify the generic commands the developer
 wants to be run. The JDBC driver translates these escape sequences into native
 syntax for its specific database. For more information consult the section 4.1.5
 from the [JDBC Technology Guide](http://java.sun.com/j2se/1.4.2/docs/guide/jdbc/getstart/statement.html#999472)
-(bundled with the Sun™ JRE documentation) and the section 13.4 from the
+(bundled with the Oracle™ JRE documentation) and the section 13.4 from the
 [JDBC 3.0 specification](http://java.sun.com/products/jdbc/download.html#corespec30).
 
 The parsing of the sql statements for these escapes can be disabled using

--- a/documentation/94/reading.md
+++ b/documentation/94/reading.md
@@ -10,8 +10,8 @@ next: index.html
 ---
 
 If you have not yet read it, you are advised you read the JDBC API Documentation
-(supplied with Sun's JDK) and the JDBC Specification.  Both are available from
-[http://java.sun.com/products/jdbc/index.jsp](http://java.sun.com/products/jdbc/index.jsp).
+(supplied with Oracle's JDK) and the JDBC Specification.  Both are available from
+[http://www.oracle.com/technetwork/java/javase/jdbc/index.html](http://www.oracle.com/technetwork/java/javase/jdbc/index.html).
 
 [http://jdbc.postgresql.org/index.html](http://jdbc.postgresql.org/index.html)
 contains updated information not included in this manual including Javadoc class

--- a/documentation/head/escapes.md
+++ b/documentation/head/escapes.md
@@ -23,7 +23,7 @@ a special escape syntax is used to specify the generic commands the developer
 wants to be run. The JDBC driver translates these escape sequences into native
 syntax for its specific database. For more information consult the section 4.1.5
 from the [JDBC Technology Guide](http://java.sun.com/j2se/1.4.2/docs/guide/jdbc/getstart/statement.html#999472)
-(bundled with the Sun™ JRE documentation) and the section 13.4 from the
+(bundled with the Oracle™ JRE documentation) and the section 13.4 from the
 [JDBC 3.0 specification](http://java.sun.com/products/jdbc/download.html#corespec30).
 
 The parsing of the sql statements for these escapes can be disabled using

--- a/documentation/head/reading.md
+++ b/documentation/head/reading.md
@@ -10,8 +10,8 @@ next: index.html
 ---
 
 If you have not yet read it, you are advised you read the JDBC API Documentation
-(supplied with Sun's JDK) and the JDBC Specification.  Both are available from
-[http://java.sun.com/products/jdbc/index.jsp](http://java.sun.com/products/jdbc/index.jsp).
+(supplied with Oracle's JDK) and the JDBC Specification.  Both are available from
+[http://www.oracle.com/technetwork/java/javase/jdbc/index.html](http://www.oracle.com/technetwork/java/javase/jdbc/index.html).
 
 [http://jdbc.postgresql.org/index.html](http://jdbc.postgresql.org/index.html)
 contains updated information not included in this manual including Javadoc class


### PR DESCRIPTION
The docs still contain references to Sun and Sun URLs. They should be
updated to reference Oracle and Oracle URLs. This PR doesn't fix all of
the Sun references and URLs. The "escapes" chapters still contains URLs
and references to the "JDBC Technology Guide" and
"JDBC 3.0 specification" which I don't know what to replace with.