### PR TITLE
docs: Update docs for Java 8 Date and Time classes

### DIFF
--- a/documentation/head/8-date-time.md
+++ b/documentation/head/8-date-time.md
@@ -1,0 +1,77 @@
+---
+layout: default_docs
+title: Using Java 8 Date and Time classes
+header: Chapter 5. Using Java 8 Date and Time classes
+resource: media
+previoustitle: Creating and Modifying Database Objects
+previous: ddl.html
+nexttitle: Chapter 6. Calling Stored Functions
+next: callproc.html
+---
+
+The PostgreSQL™ JDBC driver implements native support for the
+[Java 8 Date and Time API](http://www.oracle.com/technetwork/articles/java/jf14-date-time-2125367.html)
+(JSR-310) using JDBC 4.2.
+
+<a name="8-date-time-supported-data-types"></a>
+**Table 5.1. Supported escaped numeric functions**
+
+<table summary="Supported data type" border="1">
+  <tr>
+    <th>PostgreSQL™</th>
+    <th>Java SE 8</th>
+  </tr>
+  <tbody>
+    <tr>
+      <td>DATE</td>
+      <td>LocalDate</td>
+    </tr>
+    <tr>
+      <td>TIME [ WITHOUT TIMEZONE ]</td>
+      <td>LocalTime</td>
+    </tr>
+    <tr>
+      <td>TIMESTAMP [ WITHOUT TIMEZONE ]</td>
+      <td>LocalDateTime</td>
+    </tr>
+    <tr>
+      <td>TIMESTAMP WITH TIMEZONE</td>
+      <td>OffsetTime</td>
+    </tr>
+  </tbody>
+</table>
+
+This is closely aligned with tables B-4 and B-5 of the JDBC 4.2 specification.
+Note that `ZonedDateTime`, `Instant` and
+`OffsetTime / TIME [ WITHOUT TIMEZONE ]` are not supported. Also note
+that all `OffsetTime` will instances will have be in UTC (have offset 0).
+This is because the backend stores them as UTC.
+
+<a name="reading-example"></a>
+**Example 5.5. Reading Java 8 Date and Time values using JDBC**
+
+`Statement st = conn.createStatement();`  
+`ResultSet rs = st.executeQuery("SELECT * FROM mytable WHERE columnfoo = 500");`  
+`while (rs.next())`  
+`{`  
+&nbsp;&nbsp;&nbsp;`System.out.print("Column 1 returned ");`  
+&nbsp;&nbsp;&nbsp;`LocalDate localDate = rs.getObject(1, LocalDate.class));`  
+&nbsp;&nbsp;&nbsp;`System.out.println(localDate);`  
+`}`
+`rs.close();`  
+`st.close();` 
+
+For other data types simply pass other classes to `#getObject`.
+Note that the Java data types needs to match the SQL data types in table 7.1.
+
+
+<a name="writing-example"></a>
+**Example 5.5. Writing Java 8 Date and Time values using JDBC**
+
+`LocalDate localDate = LocalDate.now();`  
+`PreparedStatement st = conn.prepareStatement("INSERT INTO mytable (columnfoo) VALUES (?)");`  
+`st.setObject(1, localDate);`  
+`st.executeUpdate();`
+`st.close();`
+
+

--- a/documentation/head/ddl.md
+++ b/documentation/head/ddl.md
@@ -5,8 +5,8 @@ header: Chapter 5. Issuing a Query and Processing the Result
 resource: media
 previoustitle: Performing Updates
 previous: update.html
-nexttitle: Chapter 6. Calling Stored Functions
-next: callproc.html
+nexttitle: Using Java 8 Date and Time classes
+next: 8-date-time.html
 ---
 
 To create, modify or drop a database object like a table or view you use the

--- a/documentation/head/query.md
+++ b/documentation/head/query.md
@@ -16,6 +16,7 @@ next: statement.html
 * [Using the `ResultSet` Interface](resultset.html)
 * [Performing Updates](update.html)
 * [Creating and Modifying Database Objects](ddl.html)
+* [Using Java 8 Date and Time classes](8-date-time.html)
 
 Any time you want to issue SQL statements to the database, you require a `Statement`
 or `PreparedStatement` instance. Once you have a `Statement` or `PreparedStatement`,


### PR DESCRIPTION
Now that Java 8 Date and Time support has been implemented we should
document it.

When the documentation is OK can can also update the 9.4, 9.3, 9.2 "branches".