### PR TITLE
Be clear that the project use BSD 3-Clause License

### DIFF
--- a/about/license.html
+++ b/about/license.html
@@ -8,18 +8,18 @@ nav: ../
 {% include submenu_about.html %}
 
 				<div id="pgContentWrap">
-					<h1>BSD License</h1>
+					<h1>BSD 3-Clause License</h1>
 					<p>
-						The PostgreSQL JDBC driver is distributed under the BSD license, same
-						as the server.  The simplest explanation of the licensing terms is that
+						The PostgreSQL JDBC Driver is distributed under the BSD 3-Clause License.
+						The simplest explanation of the licensing terms is that
 						you can do whatever you want with the product and source code as long
 						as you don't claim you wrote it or sue us.  You should give it a read
 						though, it's only half a page.
 					</p>
 					<hr />
 
-					<pre  style="font-family: serif;">
-Copyright (c) 1997-2011, PostgreSQL Global Development Group
+					<pre  style="font-family: monospace,'Courier'; background-color: #f9f9f9; padding: 1em; border: 1px solid #ddd">
+Copyright (c) 1997-2016, PostgreSQL Global Development Group
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,5 @@ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-					</pre>
+POSSIBILITY OF SUCH DAMAGE.</pre>
 				</div> <!-- pgContentWrap -->


### PR DESCRIPTION
docs: change license page to be clear that the project use BSD 3-Clause License

Change the web page and make it clear that the project uses BSD 3-Clause License

Closes: [Issue 32](https://github.com/pgjdbc/www/issues/32)